### PR TITLE
Change status check context from 'mscape_test_build_workflow' to 'build'

### DIFF
--- a/recommended-branch-protection.json
+++ b/recommended-branch-protection.json
@@ -39,7 +39,7 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "mscape_test_build_workflow"
+            "context": "build"
           }
         ]
       }


### PR DESCRIPTION
Fix the 'build' check - if the branch protection is set incorrectly, github won't let a merge happen without passed checks, and it checks for "mscape_test_build_workflow" which doesn't exist - it's just "build".